### PR TITLE
remove dependency on cohttp-lwt-unix from library

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,4 @@
 (executable
  (name main)
  (public_name get-activity)
- (libraries get-activity cmdliner))
+ (libraries get-activity cohttp-lwt-unix cmdliner))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -97,18 +97,20 @@ let period =
 
 let info = Term.info "get-activity"
 
+module Fetch = Contributions.Fetch (Cohttp_lwt_unix.Client)
+
 let run period : unit =
   match mode with
   | `Normal ->
     with_period period (fun period ->
         (* Fmt.pr "period: %a@." Fmt.(pair string string) period; *)
         let token = get_token () |> or_die in
-        show ~from:(fst period) @@ Contributions.fetch ~period ~token
+        show ~from:(fst period) @@ (Lwt_main.run (Fetch.exec ~period ~token))
       )
   | `Save ->
     with_period period (fun period ->
         let token = get_token () |> or_die in
-        Contributions.fetch ~period ~token
+        Lwt_main.run @@ Fetch.exec ~period ~token
         |> Yojson.Safe.to_file "activity.json"
       )
   | `Load ->

--- a/dune-project
+++ b/dune-project
@@ -12,6 +12,5 @@
   cmdliner
   cohttp
   cohttp-lwt
-  cohttp-lwt-unix
   yojson
   (ocaml (>= 4.08))))

--- a/get-activity.opam
+++ b/get-activity.opam
@@ -10,7 +10,6 @@ depends: [
   "cmdliner"
   "cohttp"
   "cohttp-lwt"
-  "cohttp-lwt-unix"
   "yojson"
   "ocaml" {>= "4.08"}
 ]

--- a/lib/contributions.mli
+++ b/lib/contributions.mli
@@ -24,7 +24,9 @@ val of_yojson : Yojson.Safe.t -> t
 
 val to_yojson : t -> Yojson.Safe.t
 
-val fetch : period:(string * string) -> token:Token.t -> Yojson.Safe.t
+module Fetch : functor (C : Cohttp_lwt.S.Client) -> sig
+  val exec : period:(string * string) -> token:Token.t -> Yojson.Safe.t Lwt.t
+end
 
 val of_json : from:string -> Yojson.Safe.t -> t
 (** We pass [from] again here so we can filter out anything that GitHub included by accident. *)

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name get_activity)
  (public_name get-activity)
- (libraries cohttp cohttp-lwt cohttp-lwt-unix yojson cmdliner))
+ (libraries cohttp cohttp-lwt unix astring fmt yojson))

--- a/lib/graphql.ml
+++ b/lib/graphql.ml
@@ -4,29 +4,31 @@ let graphql_endpoint = Uri.of_string "https://api.github.com/graphql"
 
 let ( / ) a b = Yojson.Safe.Util.member b a
 
-let exec ?variables token query =
-  let body =
-    `Assoc (
-      ("query", `String query) ::
-      (match variables with
-       | None -> []
-       | Some v -> ["variables", `Assoc v])
-    )
-    |> Yojson.Safe.to_string
-    |> Cohttp_lwt.Body.of_string
-  in
-  let headers = Cohttp.Header.init_with "Authorization" ("bearer " ^ token) in
-  Cohttp_lwt_unix.Client.post ~headers ~body graphql_endpoint >>=
-  fun (resp, body) ->
-  Cohttp_lwt.Body.to_string body >|= fun body ->
-  match Cohttp.Response.status resp with
-  | `OK ->
-    let json = Yojson.Safe.from_string body in
-    begin match json / "errors" with
-      | `Null -> json
-      | _errors ->
-        Fmt.failwith "@[<v2>GitHub returned errors: %a@]" (Yojson.Safe.pretty_print ~std:true) json;
-    end
-  | err -> Fmt.failwith "@[<v2>Error performing GraphQL query on GitHub: %s@,%s@]"
-             (Cohttp.Code.string_of_status err)
-             body
+module Make (C : Cohttp_lwt.S.Client) = struct
+  let exec ?variables token query =
+    let body =
+      `Assoc (
+        ("query", `String query) ::
+        (match variables with
+        | None -> []
+        | Some v -> ["variables", `Assoc v])
+      )
+      |> Yojson.Safe.to_string
+      |> Cohttp_lwt.Body.of_string
+    in
+    let headers = Cohttp.Header.init_with "Authorization" ("bearer " ^ token) in
+    C.post ~headers ~body graphql_endpoint >>=
+    fun (resp, body) ->
+    Cohttp_lwt.Body.to_string body >|= fun body ->
+    match Cohttp.Response.status resp with
+    | `OK ->
+      let json = Yojson.Safe.from_string body in
+      begin match json / "errors" with
+        | `Null -> json
+        | _errors ->
+          Fmt.failwith "@[<v2>GitHub returned errors: %a@]" (Yojson.Safe.pretty_print ~std:true) json;
+      end
+    | err -> Fmt.failwith "@[<v2>Error performing GraphQL query on GitHub: %s@,%s@]"
+              (Cohttp.Code.string_of_status err)
+              body
+end


### PR DESCRIPTION
This PR does the usual functorising over the `cohttp` client implementation which was needed to get the magnuss/okra library to compile to jsoo nicely. 